### PR TITLE
Add: How to Search for Articles Checked Out by Users

### DIFF
--- a/how-to-search-for-articles-checked-out-by-users.md
+++ b/how-to-search-for-articles-checked-out-by-users.md
@@ -1,0 +1,39 @@
+# How to Search for Articles Checked Out by Users
+
+When a user opens an article for editing in Joomla, it becomes "checked out" to prevent other users from editing it simultaneously. However, sometimes articles remain checked out due to incomplete edits or the user forgetting to save and close. This can cause issues for other administrators or editors.
+
+Joomla allows administrators to search for these checked-out items and take action if necessary.
+
+## Step-by-Step Guide
+
+### 1. Go to Article Manager
+- Log in to your Joomla Administrator panel.
+- Navigate to **Content > Articles**.
+
+### 2. Use the Filter Options
+- In the top filters, locate the **"Select Status"** dropdown.
+- Choose **"Checked Out"** from the list.
+
+This will filter the article list and only display the items currently checked out by users.
+
+### 3. Identify the User
+- In the article list, you will see a **padlock icon** next to checked-out articles.
+- Hover over the icon or look in the **"Checked Out"** column to see who checked out the article and when.
+
+### 4. Check In the Article (If Needed)
+If the article is stuck and needs to be edited again:
+
+- Select the article(s) using the checkbox.
+- Click on **"Check-in"** in the top toolbar to manually release the lock.
+
+> ⚠️ Only users with the proper permissions can check in articles.
+
+## Tips
+- Regularly check for locked items, especially in collaborative environments.
+- Encourage users to always **Save & Close** after editing content.
+
+## Why This Matters
+✅ Prevents content lock conflicts  
+✅ Improves team workflow  
+✅ Keeps article management smooth and transparent
+


### PR DESCRIPTION
This PR introduces a new user manual article titled **"How to Search for Articles Checked Out by Users"**.

### 📄 Summary
The guide explains how Joomla admins can locate and manage articles locked due to being checked out by other users, using the Article Manager’s filters.

### ✅ What's included
- Step-by-step instructions
- Tips for effective content management
- Explanation of why this is useful for site admins

🔗 Partially addresses [#6](https://github.com/joomla/documentation/issues/6)